### PR TITLE
Update this page about Honeyswap

### DIFF
--- a/about-xdai/project-spotlights/honeyswap.md
+++ b/about-xdai/project-spotlights/honeyswap.md
@@ -9,7 +9,6 @@ The xDai team ❤ projects that deploy on our chain, but we can't provide projec
 * Honeyswap Interface: [https://honeyswap.org/\#/swap](https://honeyswap.org/#/swap)
 * More on Honey: [https://blog.1hive.org/honey/](https://blog.1hive.org/honey/)
 * xMoons on HoneySwap: [https://decrypt.co/43078/heres-how-to-sell-reddits-crypto-tokens-for-cash](https://decrypt.co/43078/heres-how-to-sell-reddits-crypto-tokens-for-cash)
-* How to get and trade the HNY token: [https://medium.com/@whitecolidon/honey-token-how-to-buy-it-c48802e2e881](https://medium.com/@whitecolidon/honey-token-how-to-buy-it-c48802e2e881)
 * [HoneyLand](https://about.1hive.org/blog/honey-land/)
 
 


### PR DESCRIPTION
Removed link : How to get and trade the HNY token: https://medium.com/@whitecolidon/honey-token-how-to-buy-it-c48802e2e881
Reason : The author has edited the article and now claims that HNY is scam token.